### PR TITLE
[2주차] 쿠폰 서비스 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "3.2.2"
     id("io.spring.dependency-management") version "1.1.4"
+    id("java-test-fixtures")
     kotlin("jvm") version "1.9.22"
     kotlin("plugin.spring") version "1.9.22"
     kotlin("plugin.jpa") version "1.9.22"
@@ -31,6 +32,8 @@ dependencies {
     testImplementation("org.junit.jupiter", "junit-jupiter", "5.8.2")
     testImplementation("org.assertj", "assertj-core", "3.22.0")
     testImplementation("io.kotest", "kotest-runner-junit5", "5.4.0")
+    testImplementation("io.mockk:mockk:1.13.4")
+    testImplementation("com.appmattus.fixture:fixture:1.2.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/example/estdelivery/adapter/in/web/CouponController.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/in/web/CouponController.kt
@@ -1,8 +1,8 @@
 package com.example.estdelivery.adapter.`in`.web
 
-import com.example.estdelivery.adapter.`in`.web.dto.ApiResponse
 import com.example.estdelivery.adapter.`in`.web.dto.CouponIssueRequest
 import com.example.estdelivery.adapter.`in`.web.dto.UserCouponResponse
+import com.example.estdelivery.application.domain.model.Result
 import com.example.estdelivery.application.domain.model.User
 import com.example.estdelivery.application.port.`in`.FindUserCouponUseCase
 import com.example.estdelivery.application.port.`in`.IssueCouponCommand
@@ -31,6 +31,6 @@ class CouponController(
     @GetMapping
     fun getCoupons(
         @UserId user: User,
-    ): ApiResponse<List<UserCouponResponse>> =
-        ApiResponse(findUserCouponUseCase.findUserCoupon(user.id))
+    ): Result.Success<List<UserCouponResponse>> =
+        Result.Success(findUserCouponUseCase.findUserCoupon(user.id))
 }

--- a/src/main/kotlin/com/example/estdelivery/adapter/in/web/CouponController.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/in/web/CouponController.kt
@@ -32,5 +32,5 @@ class CouponController(
     fun getCoupons(
         @UserId user: User,
     ): Result.Success<List<UserCouponResponse>> =
-        Result.Success(findUserCouponUseCase.findUserCoupon(user.id))
+        Result.Success(findUserCouponUseCase.findUserCoupons(user.id))
 }

--- a/src/main/kotlin/com/example/estdelivery/adapter/in/web/dto/ApiResponse.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/in/web/dto/ApiResponse.kt
@@ -1,6 +1,0 @@
-package com.example.estdelivery.adapter.`in`.web.dto
-
-data class ApiResponse<T>(
-    val result: T? = null,
-    val message: String = "",
-)

--- a/src/main/kotlin/com/example/estdelivery/adapter/in/web/dto/ErrorResponse.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/in/web/dto/ErrorResponse.kt
@@ -1,6 +1,0 @@
-package com.example.estdelivery.adapter.`in`.web.dto
-
-data class ErrorResponse(
-    val code: Int,
-    val message: String
-)

--- a/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/BaseTimeEntity.kt
@@ -1,0 +1,18 @@
+package com.example.estdelivery.adapter.out.persistence
+
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreatedDate
+    var createdAt: LocalDateTime? = null
+
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null
+}

--- a/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/coupon/CouponConfigEntity.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/coupon/CouponConfigEntity.kt
@@ -1,5 +1,6 @@
 package com.example.estdelivery.adapter.out.persistence.coupon
 
+import com.example.estdelivery.adapter.out.persistence.BaseTimeEntity
 import com.example.estdelivery.application.domain.model.CouponType
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -8,7 +9,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "coupon_configuration")
@@ -19,6 +19,4 @@ class CouponConfigEntity(
     @Enumerated(EnumType.STRING)
     val type: CouponType,
     val json: String,
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime? = null
-)
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/coupon/CouponEntity.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/coupon/CouponEntity.kt
@@ -1,11 +1,11 @@
 package com.example.estdelivery.adapter.out.persistence.coupon
 
+import com.example.estdelivery.adapter.out.persistence.BaseTimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "coupon")
@@ -15,6 +15,4 @@ class CouponEntity(
     val id: Long? = null,
     val code: String,
     val configId: Long,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-    val updatedAt: LocalDateTime? = null
-)
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/coupon/CouponMapper.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/coupon/CouponMapper.kt
@@ -2,17 +2,19 @@ package com.example.estdelivery.adapter.out.persistence.coupon
 
 import com.example.estdelivery.adapter.out.persistence.user.UserCouponEntity
 import com.example.estdelivery.application.domain.model.Coupon
+import com.example.estdelivery.application.domain.model.CouponCode
 
 
 object CouponMapper {
     fun toCoupon(couponEntity: CouponEntity): Coupon =
-        Coupon(id = couponEntity.id!!, code = couponEntity.code, configId = couponEntity.configId)
+        Coupon(id = couponEntity.id!!, code = CouponCode(couponEntity.code), configId = couponEntity.configId)
 
     fun toCoupon(userCouponEntity: UserCouponEntity): Coupon =
-        Coupon(code = userCouponEntity.couponCode, configId = userCouponEntity.couponConfigId)
+        Coupon(code = CouponCode(userCouponEntity.couponCode), configId = userCouponEntity.couponConfigId)
 
-    fun toCouponEntity(coupon: Coupon): CouponEntity = CouponEntity(code = coupon.code, configId = coupon.configId)
+    fun toCouponEntity(coupon: Coupon): CouponEntity =
+        CouponEntity(code = coupon.code.get(), configId = coupon.configId)
 
     fun toUserCouponEntity(userId: Long, coupon: Coupon): UserCouponEntity =
-        UserCouponEntity(couponCode = coupon.code, couponConfigId = coupon.configId, userId = userId)
+        UserCouponEntity(couponCode = coupon.code.get(), couponConfigId = coupon.configId, userId = userId)
 }

--- a/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/user/UserCouponEntity.kt
+++ b/src/main/kotlin/com/example/estdelivery/adapter/out/persistence/user/UserCouponEntity.kt
@@ -1,11 +1,11 @@
 package com.example.estdelivery.adapter.out.persistence.user
 
+import com.example.estdelivery.adapter.out.persistence.BaseTimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "user_coupon")
@@ -16,6 +16,4 @@ class UserCouponEntity(
     val couponCode: String,
     val couponConfigId: Long,
     val userId: Long,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-    val updatedAt: LocalDateTime? = null
-)
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/example/estdelivery/application/domain/model/Coupon.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/domain/model/Coupon.kt
@@ -4,11 +4,13 @@ import com.example.estdelivery.common.utils.SnowflakeIdGeneratorUtils
 
 data class Coupon(
     val id: Long? = null,
-    var code: String,
+    var code: CouponCode,
     val configId: Long
 ) {
     companion object {
-        fun create(configId: Long): Coupon =
-            Coupon(code = SnowflakeIdGeneratorUtils.generateId(1).toString(), configId = configId)
+        fun create(configId: Long): Coupon = Coupon(
+            code = CouponCode(SnowflakeIdGeneratorUtils.generateId(1)),
+            configId = configId
+        )
     }
 }

--- a/src/main/kotlin/com/example/estdelivery/application/domain/model/CouponCode.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/domain/model/CouponCode.kt
@@ -1,12 +1,13 @@
 package com.example.estdelivery.application.domain.model
 
+import com.example.estdelivery.common.Constant.COUPON_CODE_LENGTH
 import com.example.estdelivery.common.exception.CommonException
 import com.example.estdelivery.common.exception.ErrorCode
 
 @JvmInline
 value class CouponCode(private val value: String) {
     init {
-        require(value.length != 17) { throw CommonException(ErrorCode.INVALID_COUPON_CODE) }
+        require(value.length == COUPON_CODE_LENGTH) { throw CommonException(ErrorCode.INVALID_COUPON_CODE) }
     }
 
     fun get(): String = value

--- a/src/main/kotlin/com/example/estdelivery/application/domain/model/CouponCode.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/domain/model/CouponCode.kt
@@ -1,0 +1,13 @@
+package com.example.estdelivery.application.domain.model
+
+import com.example.estdelivery.common.exception.CommonException
+import com.example.estdelivery.common.exception.ErrorCode
+
+@JvmInline
+value class CouponCode(private val value: String) {
+    init {
+        require(value.length != 17) { throw CommonException(ErrorCode.INVALID_COUPON_CODE) }
+    }
+
+    fun get(): String = value
+}

--- a/src/main/kotlin/com/example/estdelivery/application/domain/model/Result.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/domain/model/Result.kt
@@ -1,0 +1,13 @@
+package com.example.estdelivery.application.domain.model
+
+sealed class Result {
+    data class Success<T>(
+        val data: T? = null,
+        val message: String = ""
+    )
+
+    data class Error(
+        val code: Int,
+        val message: String
+    )
+}

--- a/src/main/kotlin/com/example/estdelivery/application/domain/service/FindUserCouponService.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/domain/service/FindUserCouponService.kt
@@ -12,5 +12,5 @@ class FindUserCouponService(
     val findUserCouponPort: FindUserCouponPort
 ) : FindUserCouponUseCase {
     override fun findUserCoupon(userId: Long): List<UserCouponResponse> =
-        findUserCouponPort.findByUserId(userId).map { UserCouponResponse(it.code, it.configId) }
+        findUserCouponPort.findByUserId(userId).map { UserCouponResponse(it.code.get(), it.configId) }
 }

--- a/src/main/kotlin/com/example/estdelivery/application/domain/service/FindUserCouponService.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/domain/service/FindUserCouponService.kt
@@ -11,6 +11,6 @@ import org.springframework.transaction.annotation.Transactional
 class FindUserCouponService(
     val findUserCouponPort: FindUserCouponPort
 ) : FindUserCouponUseCase {
-    override fun findUserCoupon(userId: Long): List<UserCouponResponse> =
+    override fun findUserCoupons(userId: Long): List<UserCouponResponse> =
         findUserCouponPort.findByUserId(userId).map { UserCouponResponse(it.code.get(), it.configId) }
 }

--- a/src/main/kotlin/com/example/estdelivery/application/port/in/FindUserCouponUseCase.kt
+++ b/src/main/kotlin/com/example/estdelivery/application/port/in/FindUserCouponUseCase.kt
@@ -3,5 +3,5 @@ package com.example.estdelivery.application.port.`in`
 import com.example.estdelivery.adapter.`in`.web.dto.UserCouponResponse
 
 interface FindUserCouponUseCase {
-    fun findUserCoupon(userId: Long): List<UserCouponResponse>
+    fun findUserCoupons(userId: Long): List<UserCouponResponse>
 }

--- a/src/main/kotlin/com/example/estdelivery/common/Constant.kt
+++ b/src/main/kotlin/com/example/estdelivery/common/Constant.kt
@@ -3,4 +3,5 @@ package com.example.estdelivery.common
 object Constant {
     const val X_AUTHENTICATED_USER = "X-Authenticated-User"
     const val MAX_MACHINE_ID_LENGTH = 5
+    const val COUPON_CODE_LENGTH = 17
 }

--- a/src/main/kotlin/com/example/estdelivery/common/Constant.kt
+++ b/src/main/kotlin/com/example/estdelivery/common/Constant.kt
@@ -2,4 +2,5 @@ package com.example.estdelivery.common
 
 object Constant {
     const val X_AUTHENTICATED_USER = "X-Authenticated-User"
+    const val MAX_MACHINE_ID_LENGTH = 5
 }

--- a/src/main/kotlin/com/example/estdelivery/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/estdelivery/common/exception/ErrorCode.kt
@@ -9,6 +9,7 @@ enum class ErrorCode(
 ) {
     DUPLICATED_COUPON(1000, HttpStatus.BAD_REQUEST, "duplicated coupon."),
     NOT_FOUND_COUPON_CONFIG(1001, HttpStatus.NOT_FOUND, "not found coupon config."),
-    UNAUTHORIZED(401, HttpStatus.UNAUTHORIZED, "user id is required.")
+    UNAUTHORIZED(401, HttpStatus.UNAUTHORIZED, "user id is required."),
+    INVALID_COUPON_CODE(1002, HttpStatus.INTERNAL_SERVER_ERROR, "invalid coupon code.")
     ;
 }

--- a/src/main/kotlin/com/example/estdelivery/common/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/example/estdelivery/common/exception/ExceptionHandler.kt
@@ -1,6 +1,6 @@
 package com.example.estdelivery.common.exception
 
-import com.example.estdelivery.adapter.`in`.web.dto.ErrorResponse
+import com.example.estdelivery.application.domain.model.Result
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -8,10 +8,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 @RestControllerAdvice
 class ExceptionHandler {
     @ExceptionHandler(CommonException::class)
-    protected fun handleCommonException(exception: CommonException): ResponseEntity<ErrorResponse> =
+    protected fun handleCommonException(exception: CommonException): ResponseEntity<Result.Error> =
         ResponseEntity.status(exception.errorCode.status)
             .body(
-                ErrorResponse(
+                Result.Error(
                     exception.errorCode.code,
                     exception.errorCode.message
                 )

--- a/src/main/kotlin/com/example/estdelivery/common/utils/SnowflakeIdGeneratorUtils.kt
+++ b/src/main/kotlin/com/example/estdelivery/common/utils/SnowflakeIdGeneratorUtils.kt
@@ -1,11 +1,11 @@
 package com.example.estdelivery.common.utils
 
+import com.example.estdelivery.common.Constant.MAX_MACHINE_ID_LENGTH
 import java.time.Instant
 
 object SnowflakeIdGeneratorUtils {
-    private const val machineIdBits = 5
     private const val sequenceBits = 12
-    private const val maxMachineId = (-1L).xor(-1L shl machineIdBits)
+    private const val maxMachineId = (-1L).xor(-1L shl MAX_MACHINE_ID_LENGTH)
     private const val sequenceMask = (-1L).xor(-1L shl sequenceBits)
 
     private var lastTimestamp = -1L

--- a/src/main/kotlin/com/example/estdelivery/common/utils/SnowflakeIdGeneratorUtils.kt
+++ b/src/main/kotlin/com/example/estdelivery/common/utils/SnowflakeIdGeneratorUtils.kt
@@ -11,7 +11,7 @@ object SnowflakeIdGeneratorUtils {
     private var lastTimestamp = -1L
     private var sequence = 0L
 
-    fun generateId(machineId: Long, epoch: Long = 1627862400000L): Long {
+    fun generateId(machineId: Long, epoch: Long = 1627862400000L): String {
         require(machineId in 0..maxMachineId) { "Machine ID must be between 0 and $maxMachineId" }
 
         var timestamp = timeGen()
@@ -31,7 +31,7 @@ object SnowflakeIdGeneratorUtils {
 
         lastTimestamp = timestamp
 
-        return ((timestamp - epoch) shl (machineIdBits + sequenceBits)) or (machineId shl sequenceBits) or sequence
+        return (((timestamp - epoch) shl (machineIdBits + sequenceBits)) or (machineId shl sequenceBits) or sequence).toString()
     }
 
     private fun tilNextMillis(lastTimestamp: Long): Long {

--- a/src/main/kotlin/com/example/estdelivery/common/utils/SnowflakeIdGeneratorUtils.kt
+++ b/src/main/kotlin/com/example/estdelivery/common/utils/SnowflakeIdGeneratorUtils.kt
@@ -31,7 +31,7 @@ object SnowflakeIdGeneratorUtils {
 
         lastTimestamp = timestamp
 
-        return (((timestamp - epoch) shl (machineIdBits + sequenceBits)) or (machineId shl sequenceBits) or sequence).toString()
+        return (((timestamp - epoch) shl (MAX_MACHINE_ID_LENGTH + sequenceBits)) or (machineId shl sequenceBits) or sequence).toString()
     }
 
     private fun tilNextMillis(lastTimestamp: Long): Long {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,6 @@
-INSERT INTO coupon_configuration (type, json, created_at) VALUES ('DISCOUNT', '{"discount_percentage": "20%"}', now());
-INSERT INTO coupon_configuration (type, json, created_at) VALUES ('AMOUNT', '{"price": "3000"}', now());
-INSERT INTO coupon_configuration (type, json, created_at) VALUES ('DISCOUNT', '{"discount_percentage": "10%"}', now());
+INSERT INTO coupon_configuration (type, json, created_at)
+VALUES ('DISCOUNT', '{"discount_percentage": "20%"}', now());
+INSERT INTO coupon_configuration (type, json, created_at)
+VALUES ('AMOUNT', '{"price": "3000"}', now());
+INSERT INTO coupon_configuration (type, json, created_at)
+VALUES ('DISCOUNT', '{"discount_percentage": "10%"}', now());

--- a/src/test/kotlin/com/example/estdelivery/usecase/FindUserCouponUseCaseTest.kt
+++ b/src/test/kotlin/com/example/estdelivery/usecase/FindUserCouponUseCaseTest.kt
@@ -1,0 +1,26 @@
+package com.example.estdelivery.usecase
+
+import CouponTestFixture
+import com.example.estdelivery.application.domain.service.FindUserCouponService
+import com.example.estdelivery.application.port.out.FindUserCouponPort
+import io.kotest.core.spec.style.FreeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class FindUserCouponUseCaseTest : FreeSpec({
+    val findUserCouponPort = mockk<FindUserCouponPort>()
+
+    val findUserCouponService = FindUserCouponService(findUserCouponPort)
+
+    "findUserCoupons" - {
+        "주어진 사용자의 쿠폰 정보를 조회한다" - {
+            val userId = 1L
+            every { findUserCouponPort.findByUserId(any()) } returns CouponTestFixture.coupons()
+
+            findUserCouponService.findUserCoupons(userId)
+
+            verify { findUserCouponPort.findByUserId(userId) }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/estdelivery/usecase/IssueCouponUseCaseTest.kt
+++ b/src/test/kotlin/com/example/estdelivery/usecase/IssueCouponUseCaseTest.kt
@@ -1,0 +1,71 @@
+package com.example.estdelivery.usecase
+
+import CouponConfigTestFixture
+import CouponTestFixture
+import com.example.estdelivery.application.domain.service.IssueCouponService
+import com.example.estdelivery.application.port.`in`.IssueCouponCommand
+import com.example.estdelivery.application.port.out.CreateCouponPort
+import com.example.estdelivery.application.port.out.FindCouponConfigPort
+import com.example.estdelivery.application.port.out.FindUserCouponPort
+import com.example.estdelivery.application.port.out.IssueUserCouponPort
+import com.example.estdelivery.common.exception.CommonException
+import com.example.estdelivery.common.exception.ErrorCode
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.assertThrows
+
+class IssueCouponUseCaseTest : FreeSpec({
+    val findCouponConfigPort = mockk<FindCouponConfigPort>()
+    val createCouponPort = mockk<CreateCouponPort>()
+    val issueUserCouponPort = mockk<IssueUserCouponPort>()
+    val findUserCouponPort = mockk<FindUserCouponPort>()
+
+    val issueCouponService =
+        IssueCouponService(findCouponConfigPort, createCouponPort, issueUserCouponPort, findUserCouponPort)
+
+    "issueCoupon" - {
+        "사용자에게 쿠폰을 발급한다" - {
+            val userId = 1L
+            val couponConfigId = 1L
+            val issueCouponCommand = IssueCouponCommand(userId, couponConfigId)
+
+            "오늘 동일한 쿠폰을 발급받은 경우" - {
+                "DUPLICATED_COUPON Exception 처리한다" - {
+                    every { findCouponConfigPort.findCouponConfig(any()) } returns CouponConfigTestFixture.couponConfig()
+                    every { findUserCouponPort.existsIssuedUserCoupon(any(), any()) } returns true
+                    every { createCouponPort.createCoupon(any()) } returns CouponTestFixture.coupon()
+                    every { issueUserCouponPort.issueUserCoupon(any(), any()) } returns mockk()
+
+                    val exception = assertThrows<CommonException> {
+                        issueCouponService.issueCoupon(issueCouponCommand)
+                    }
+
+                    exception.errorCode shouldBe ErrorCode.DUPLICATED_COUPON
+                    verify { findCouponConfigPort.findCouponConfig(couponConfigId) }
+                    verify { findUserCouponPort.existsIssuedUserCoupon(userId, any()) }
+                    verify(exactly = 0) { createCouponPort.createCoupon(any()) }
+                    verify(exactly = 0) { issueUserCouponPort.issueUserCoupon(userId, any()) }
+                }
+            }
+
+            "오늘 동일한 쿠폰을 발급받지 않은 경우" - {
+                "쿠폰 발급에 성공한다" - {
+                    every { findCouponConfigPort.findCouponConfig(any()) } returns CouponConfigTestFixture.couponConfig()
+                    every { findUserCouponPort.existsIssuedUserCoupon(any(), any()) } returns false
+                    every { createCouponPort.createCoupon(any()) } returns CouponTestFixture.coupon()
+                    every { issueUserCouponPort.issueUserCoupon(any(), any()) } returns mockk()
+
+                    issueCouponService.issueCoupon(issueCouponCommand)
+
+                    verify { findCouponConfigPort.findCouponConfig(couponConfigId) }
+                    verify { findUserCouponPort.existsIssuedUserCoupon(userId, any()) }
+                    verify { createCouponPort.createCoupon(any()) }
+                    verify { issueUserCouponPort.issueUserCoupon(userId, any()) }
+                }
+            }
+        }
+    }
+})

--- a/src/testFixtures/kotlin/CouponConfigTestFixture.kt
+++ b/src/testFixtures/kotlin/CouponConfigTestFixture.kt
@@ -1,0 +1,6 @@
+import com.example.estdelivery.application.domain.model.CouponConfig
+import com.example.estdelivery.application.domain.model.CouponType
+
+object CouponConfigTestFixture {
+    fun couponConfig(): CouponConfig = CouponConfig(1, CouponType.AMOUNT, "")
+}

--- a/src/testFixtures/kotlin/CouponTestFixture.kt
+++ b/src/testFixtures/kotlin/CouponTestFixture.kt
@@ -1,0 +1,7 @@
+import com.example.estdelivery.application.domain.model.Coupon
+
+object CouponTestFixture {
+    fun coupon(): Coupon = Coupon.create(1)
+
+    fun coupons(): List<Coupon> = listOf(Coupon.create(1), Coupon.create(2))
+}


### PR DESCRIPTION
# 수정사항
- 헤더로 전달받은 사용자 ID 에 resolver 적용
- 공통 상수 값 분리
- 응답객체를 Result 도메인으로 관리하도록 변경
- jpa auditing 적용
- usecase 테스트 코드 작성
- 쿠폰 코드 속성을 도메인 클래스로 분리